### PR TITLE
Stub out the old -xenbattery qemu cmdline arg.

### DIFF
--- a/src/ioemu-device.c
+++ b/src/ioemu-device.c
@@ -261,6 +261,7 @@ static  bool xen_pci_pt_device_parse_options (struct device_model *devmodel,
 
 ioemu_device_init (xen_pci_pt, xen_pci_pt_device_parse_options);
 
+/* OXT-217 this will be re-used as the xen_acpi_pm param
 static  bool xenbattery_device_parse_options (struct device_model *devmodel,
                                               const char *device)
 {
@@ -269,4 +270,4 @@ static  bool xenbattery_device_parse_options (struct device_model *devmodel,
 
     return true;
 }
-ioemu_device_init (xenbattery, xenbattery_device_parse_options);
+ioemu_device_init (xenbattery, xenbattery_device_parse_options);*/

--- a/src/qemu-device.c
+++ b/src/qemu-device.c
@@ -290,6 +290,7 @@ static  bool xenmou_device_parse_options (struct device_model *devmodel,
 
 qemu_device_init (xenmou, xenmou_device_parse_options);
 
+/* OXT-217 this will be re-used as the xen_acpi_pm param
 static  bool xenbattery_device_parse_options (struct device_model *devmodel,
                                               const char *device)
 {
@@ -300,7 +301,7 @@ static  bool xenbattery_device_parse_options (struct device_model *devmodel,
     return true;
 }
 
-qemu_device_init (xenbattery, xenbattery_device_parse_options);
+qemu_device_init (xenbattery, xenbattery_device_parse_options);*/
 
 static  bool xen_pci_pt_device_parse_options (struct device_model *devmodel,
                                               const char *device)


### PR DESCRIPTION
The param will be reused later for the updated acpi pm functionality. Oh and
sorry for being a muppet and breaking the build.

OXT-262

Signed-off-by: Ross Philipson philipsonr@ainfosec.com
