### PR TITLE
Pass max-ram-below-4g to QEMU

### DIFF
--- a/src/domain.c
+++ b/src/domain.c
@@ -172,6 +172,16 @@ static bool domain_get_info (struct domain *domain)
     domain->memkb = atoi (val);
     free (val);
 
+    val = xenstore_read ("%s/memory/tolum", dompath);
+    if (val) {
+        domain_info (domain, "retrieve TOLUM.");
+        domain->tolum = strtoul (val, NULL, 0);
+        domain_info (domain, "TOLUM=%#lx.", domain->tolum);
+        free(val);
+    } else {
+        domain->tolum = 0;
+    }
+
     val = xenstore_read ("%s/platform/vcpu_number", dompath);
     if (!val)
         goto err_get_info;

--- a/src/domain.h
+++ b/src/domain.h
@@ -35,6 +35,8 @@ struct domain
     struct event ev_destroy;
     /* amount of domain RAM */
     unsigned long memkb;
+    /* maximum available RAM before the 4G limit. */
+    unsigned long tolum;
     /* number of vpcus */
     unsigned int vcpus;
     /* boot order */

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -144,7 +144,11 @@ static bool spawn_qemu_args (struct device_model *devmodel)
                    devmodel->dmid);
 
     SPAWN_ADD_ARG (devmodel, "-machine");
-    SPAWN_ADD_ARG (devmodel, "xenfv");
+    if (devmodel->domain->tolum) {
+        SPAWN_ADD_ARG (devmodel, "xenfv,max-ram-below-4g=%#lx", devmodel->domain->tolum);
+    } else {
+        SPAWN_ADD_ARG (devmodel, "xenfv");
+    }
 
     SPAWN_ADD_ARG (devmodel, "-m");
     SPAWN_ADD_ARG (devmodel, "%lu", devmodel->domain->memkb >> 10);


### PR DESCRIPTION
Takes the optional value at /local/domain/<domid>/memory/tolum and pass
it to qemu max-ram-below-4g option. Ignore if the value is not provided.

The full fix for OXT-243 includes the toolstack commit to process that value before starting QEMU and the QEMU patch to notify the Xen memory listener and the i440fx emulation.
