### PR TITLE
Patches to repo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,13 +18,12 @@
 
 # Prelude.
 AC_PREREQ(2.13)
-AC_INIT()
+m4_include([version.m4])
+AC_INIT([dm-agent], DM_AGENT_VERSION)
 
 LT_INIT
 
-PACKAGE=dm-agent
-
-AM_INIT_AUTOMAKE($PACKAGE,$VERSION)
+AM_INIT_AUTOMAKE([foreign])
 
 # Checks for programs.
 AC_PROG_CC

--- a/src/domain.c
+++ b/src/domain.c
@@ -19,6 +19,7 @@
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>
+# include <inttypes.h>
 # include "domain.h"
 # include "dm-agent.h"
 # include "util.h"
@@ -118,7 +119,7 @@ void domains_watch (const char *path, void *priv)
 
     (void) priv;
 
-    res = asprintf (&buff, "%s/dms/%%u", dm_agent_get_path ());
+    res = asprintf (&buff, "%s/dms/%%"SCNu16, dm_agent_get_path ());
     if (res == -1)
         return;
 

--- a/src/util.c
+++ b/src/util.c
@@ -16,7 +16,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>

--- a/version.m4
+++ b/version.m4
@@ -1,0 +1,1 @@
+m4_define([DM_AGENT_VERSION], $VERSION)


### PR DESCRIPTION
dm-agent patches were left in the layer. They belong to the dm-agent repository.

See related https://github.com/OpenXT/xenclient-oe/pull/241.
